### PR TITLE
Add 'requestedAt' column and generate migration

### DIFF
--- a/db/migrations/1701934596047-AddRequestedAtToUserTable.ts
+++ b/db/migrations/1701934596047-AddRequestedAtToUserTable.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRequestedAtToUserTable1701934596047
+  implements MigrationInterface
+{
+  name = 'AddRequestedAtToUserTable1701934596047';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`user\` ADD \`requestedAt\` datetime NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`user\` DROP COLUMN \`requestedAt\``);
+  }
+}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -22,4 +22,7 @@ export class User {
 
   @Column({ nullable: true, length: 4 })
   otp: string;
+
+  @Column({ nullable: true })
+  requestedAt: Date;
 }


### PR DESCRIPTION
Add an additional `requestedAt` field in the database to store the created time of the OTP.